### PR TITLE
Use github.com/robfig/cron/v3 to parse standard cron specs + timezone

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,28 +3,9 @@ module github.com/jsiebens/nomad-autoscaler-plugin-strategy-cron
 go 1.17
 
 require (
-	github.com/hashicorp/cronexpr v1.1.1
 	github.com/hashicorp/go-hclog v1.0.0
 	github.com/hashicorp/nomad-autoscaler v0.3.3
 	github.com/stretchr/testify v1.7.0
 )
 
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.10.0 // indirect
-	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/hashicorp/go-plugin v1.0.1 // indirect
-	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
-	github.com/mattn/go-colorable v0.1.8 // indirect
-	github.com/mattn/go-isatty v0.0.12 // indirect
-	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/oklog/run v1.0.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
-	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 // indirect
-	golang.org/x/text v0.3.6 // indirect
-	google.golang.org/genproto v0.0.0-20210119180700-e258113e47cc // indirect
-	google.golang.org/grpc v1.35.0 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-)
+require github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -231,7 +231,6 @@ github.com/hashicorp/consul/api v1.8.0/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+Xbo
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.7.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/cronexpr v1.1.0/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
-github.com/hashicorp/cronexpr v1.1.1 h1:NJZDd87hGXjoZBdvyCF9mX4DCq5Wy7+A/w+A7q0wn6c=
 github.com/hashicorp/cronexpr v1.1.1/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -427,6 +426,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -57,9 +57,9 @@ func TestStrategyPlugin_calculateTargetCount(t *testing.T) {
 
 	config := map[string]string{
 		"count":           "1",
-		"period_business": "* * 9-17 * * mon-fri * -> 10",
-		"period_mon_100":  "* * 9-17 * * mon * -> 7",
-		"period_sat":      "* * * * * sat * -> 5",
+		"period_business": "* 9-17 * * mon-fri -> 10",
+		"period_mon_100":  "* 9-17 * * mon -> 7",
+		"period_sat":      "* * * * sat -> 5",
 	}
 
 	testCases := []struct {

--- a/plugin/rule.go
+++ b/plugin/rule.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/cronexpr"
+	"github.com/robfig/cron/v3"
 )
 
 func parsePeriodRule(key, value, separator string) (*Rule, error) {
@@ -15,7 +15,8 @@ func parsePeriodRule(key, value, separator string) (*Rule, error) {
 	entries := strings.Split(value, separator)
 
 	period := strings.TrimSpace(entries[0])
-	expr, err := cronexpr.Parse(period)
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	expr, err := parser.Parse(period)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +46,7 @@ func parsePeriodRule(key, value, separator string) (*Rule, error) {
 }
 
 type Rule struct {
-	expr     *cronexpr.Expression
+	expr     cron.Schedule
 	period   string
 	key      string
 	count    int64
@@ -55,7 +56,7 @@ type Rule struct {
 func (t *Rule) InPeriod(now time.Time) bool {
 	nextIn := t.expr.Next(now)
 	timeSince := now.Sub(nextIn)
-	if -time.Second <= timeSince && timeSince <= time.Second {
+	if -time.Minute <= timeSince && timeSince <= time.Minute {
 		return true
 	}
 

--- a/plugin/rule_test.go
+++ b/plugin/rule_test.go
@@ -16,12 +16,12 @@ func TestRule_New(t *testing.T) {
 	}{
 		{
 			name:          "period_default",
-			inputValue:    "* * 9-17 * * mon-fri *",
+			inputValue:    "* 9-17 * * mon-fri",
 			expectedCount: 1,
 		},
 		{
 			name:          "period_valid_count",
-			inputValue:    "* * 9-17 * * mon-fri *;5",
+			inputValue:    "* 9-17 * * mon-fri;5",
 			expectedCount: 5,
 		},
 		{
@@ -31,7 +31,7 @@ func TestRule_New(t *testing.T) {
 		},
 		{
 			name:          "period_invalid_count",
-			inputValue:    "* * 9-17 * * mon-fri *;invalid",
+			inputValue:    "* 9-17 * * mon-fri;invalid",
 			expectedError: true,
 		},
 	}


### PR DESCRIPTION
Breaking change:
use github.com/robfig/cron/v3 as a cron parser. That means: standard crontab format (5 entries) and the ability to add a timezone via a "CRON_TZ="-prefix.